### PR TITLE
Added the union of two types, strings and substrings to CooMatrix()

### DIFF
--- a/src/coom.jl
+++ b/src/coom.jl
@@ -187,7 +187,7 @@ sparse([2, 3, 4, 5, 6, 1, 3, 4, 5, 6, 7, 1, 2, 4, 5, 6, 7, 8, 1, 2, 3, 5, 6, 7, 
 ```
 """
 function CooMatrix{T}(doc,
-                      terms::Vector{String};
+                      terms::Vector{Union{String, SubString{String}}};
                       window::Int=5,
                       direction::Bool=false,
                       normalize::Bool=true) where T<:AbstractFloat
@@ -198,14 +198,14 @@ function CooMatrix{T}(doc,
 end
 
 function CooMatrix{T}(doc::NGramDocument,
-                      terms::Vector{String};
+                      terms::Vector{Union{String, SubString{String}}};
                       window::Int=5,
                       direction::Bool=false,
                       normalize::Bool=true) where T <: AbstractFloat
     error("The Co occurrence matrix of an NGramDocument can't be created.")
 end
 
-CooMatrix(doc, terms::Vector{String}; window::Int=5, direction::Bool=false, normalize::Bool=true) =
+CooMatrix(doc, terms::Vector{Union{String, SubString{String}}}; window::Int=5, direction::Bool=false, normalize::Bool=true) =
     CooMatrix{Float64}(doc, terms, window=window, direction=direction, normalize=normalize)
 
 function CooMatrix{T}(doc; window::Int=5, direction::Bool=false, normalize::Bool=true) where T<:AbstractFloat


### PR DESCRIPTION
Hi!

The reason for these type additions is that if one would like to use a vocabulary of terms with CooMatrix() and they want to tokenize any string for getting the vocabulary, I found out that `punctuation_space_tokenize()` from `WordTokenizers` is much faster than the `tokenize()` function and is also very practical in terms of tokenization criteria. However, if one wants to use it, it returns `SubString{String}`s and not `String`s and therefore its output cannot be the terms (vocabulary) arguments of `CooMatrix()`. 

Regards.

Alex